### PR TITLE
chore: supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Install Foundry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 env:
   FOUNDRY_PROFILE: ci
 
@@ -13,12 +16,12 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
         with:
           version: nightly
 


### PR DESCRIPTION
Applies the `repo-hardening` skill — minimal workflow hardening on a Solidity/Foundry repo.

## Repo posture
- Type: **Solidity/Foundry** — `package.json` exists but is empty (no JS deps, no lockfile)
- Overnight plan listed this in tier 1 (no-lockfile) but the actual surface is Solidity-only
- One workflow: `test.yml` (manual-trigger Foundry test)

## Controls applied
- [x] 10. Workflow permissions — `permissions: contents: read` added to `test.yml`
- [x] 11. Actions pinned to SHA — `actions/checkout@v3` → SHA for v4.2.2; `foundry-rs/foundry-toolchain@v1` → SHA for v1.4.0
- [x] 8. Dependabot cooldown — added `.github/dependabot.yml` for `github-actions` (only relevant ecosystem)

## Skipped (out of scope for this repo)
- 1, 2, 3, 4, 5, 6, 7, 9 — no JS deps, no Dockerfile

## ⚠️ Needs review
- Plan listed this as "no-lockfile" — but the repo is Solidity-only with an empty `package.json`. Confirm whether this PR is even worth opening (small but real workflow-hardening value).
- `actions/checkout` was bumped from v3 → v4 (major). Verify the Foundry test workflow still runs.